### PR TITLE
Update lambdasoup dependency

### DIFF
--- a/soupault.opam
+++ b/soupault.opam
@@ -37,7 +37,7 @@ depends: [
   "fileutils" {>= "0.6.3"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
-  "lambdasoup" {>= "1.0.0"}
+  "lambdasoup" {>= "1.1.0"}
   "markup" {>= "1.0.0-1"}
   "otoml" {>= "1.0.5"}
   "ezjsonm" {>= "1.2.0"}


### PR DESCRIPTION
v1.1.0 of lambdasoup makes available the `:has()` CSS selector, which becomes immediately usable in soupault.

It also provides `Soup.is_document` and `Soup.is_text` functions, which will be used to enrich soupault API later on.