### PR TITLE
Improve the HTML node type checking API

### DIFF
--- a/src/plugin_api.ml
+++ b/src/plugin_api.ml
@@ -176,6 +176,9 @@ module Html = struct
     | ElementNode n -> Soup.coerce n
     | SoupNode n -> Soup.coerce n
 
+  let is_text n =
+    n |> to_general |> Soup.is_text 
+
   let to_soup n =
     match n with
     | SoupNode n -> n

--- a/src/plugin_api.ml
+++ b/src/plugin_api.ml
@@ -188,9 +188,7 @@ module Html = struct
     to_general n |> Soup.is_root
 
   let is_document n =
-    match n with
-    | SoupNode _ -> true
-    | _ -> false
+    to_general n |> Soup.is_document
 
   let select soup selector =
     let* soup = soup in


### PR DESCRIPTION
This PR adds an `is_text` function to plugin API.

Also, it simplifies `is_document` function of the plugin API by just calling the `is_document` function of the underlying lambdasoup library.