### PR TITLE
Create Sys.strip_extension() API function

### DIFF
--- a/src/helpers/file_path.ml
+++ b/src/helpers/file_path.ml
@@ -39,6 +39,13 @@ let strip_extensions file =
   let (name, _) = split_file_name file in
   name
 
+(* Removes the last extension from a file name. Same as strip_extensions for 0 or 1 extensions. *)
+let strip_extension file =
+  let (name, extensions) = split_file_name file in
+  match (List.rev extensions) with
+  | [] | [_] -> name
+  | last :: remain -> String.concat "." (name :: List.rev remain)
+
 (* Checks if a file name has a certain extension in it.
    It doesn't have to be the last extension:
    [has_extension "tar" "file.tar.gz"] is true.

--- a/src/plugin_api.ml
+++ b/src/plugin_api.ml
@@ -123,6 +123,11 @@ module Sys_wrappers = struct
     try File_path.strip_extensions f
     with Malformed_file_name name ->
       Printf.ksprintf plugin_error {|Malformed file name "%s" in a call to Sys.strip_extensions|} name
+
+  let strip_extension f =
+    try File_path.strip_extension f
+    with Malformed_file_name name ->
+      Printf.ksprintf plugin_error {|Malformed file name "%s" in a call to Sys.strip_extension|} name
 end
 
 module Plugin_version = struct
@@ -979,6 +984,7 @@ struct
        "get_extensions", V.efunc (V.string **->> V.list V.string) Sys_wrappers.get_extensions;
        "has_extension", V.efunc (V.string **-> V.string **->> V.bool) (fun f e -> Sys_wrappers.has_extension e f);
        "strip_extensions", V.efunc (V.string **->> V.string) Sys_wrappers.strip_extensions;
+       "strip_extension", V.efunc (V.string **->> V.string) Sys_wrappers.strip_extension;
        (* Misc. *)
        "random", V.efunc (V.int **->> V.int) Random.int;
        "is_windows", V.efunc (V.unit **->> V.bool) (fun () -> Sys.win32);


### PR DESCRIPTION
Removes only the last extension from a path. Complement to
Sys.get_extension().
