### PR TITLE
Fix typo in `project_init.ml`

### DIFF
--- a/src/project_init.ml
+++ b/src/project_init.ml
@@ -61,7 +61,7 @@ let make_default_config settings = Printf.sprintf {|
 
   # By default, soupault uses "clean URLs",
   # that is, $site_dir/page.html is converted to $build_dir/page/index.html
-  # You can make it produce $build_dir/page.tml instead by changing this option to false
+  # You can make it produce $build_dir/page.html instead by changing this option to false
   clean_urls = true
 
   # If you set clean_urls=false,


### PR DESCRIPTION
Adds a missing `h` to `page.html` in the comment describing the `clean_urls` setting.