### PR TITLE
Optionally render math delimiters as html

### DIFF
--- a/src/common.ml
+++ b/src/common.ml
@@ -254,6 +254,9 @@ type settings = {
   markdown_smart_apostrophe: bool;
   markdown_smart_ellipsis: bool;
 
+  (* Render math delimiters in the default CMarkit way or as html *)
+  markdown_math_delimiters_html: bool;
+
   (* Files to ignore completely. *)
   ignore_extensions: string list;
   ignore_path_regexes: string list;
@@ -395,6 +398,7 @@ let default_settings = {
   markdown_smart_quotes = true;
   markdown_smart_apostrophe = true;
   markdown_smart_ellipsis = true;
+  markdown_math_delimiters_html = false;
   ignore_extensions = [];
   ignore_path_regexes = [];
   ignore_directories = [];

--- a/src/config.ml
+++ b/src/config.ml
@@ -448,6 +448,7 @@ let valid_settings = [
   "markdown_smart_punctuation";
   "markdown_smart_quotes"; "markdown_smart_apostrophe";
   "markdown_smart_dashes"; "markdown_smart_ellipsis";
+  "markdown_math_delimiters_html";
   "ignore_path_regexes"; "ignore_directories";
   "complete_page_selector"; "generator_mode";
   "plugin_dirs"; "plugin_discovery";
@@ -501,6 +502,7 @@ let _update_settings settings config =
        markdown_smart_quotes = find_bool_or ~default:settings.markdown_smart_quotes st ["markdown_smart_quotes"];
        markdown_smart_apostrophe = find_bool_or ~default:settings.markdown_smart_apostrophe st ["markdown_smart_apostrophe"];
        markdown_smart_ellipsis = find_bool_or ~default:settings.markdown_smart_ellipsis st ["markdown_smart_ellipsis"];
+       markdown_math_delimiters_html = find_bool_or ~default:settings.markdown_math_delimiters_html st ["markdown_math_delimiters_html"];
        ignore_extensions = find_strings_or ~default:[] st ["ignore_extensions"];
        ignore_path_regexes = find_strings_or ~default:[] st ["ignore_path_regexes"];
        ignore_directories = find_strings_or ~default:[] st ["ignore_directories"];
@@ -605,6 +607,7 @@ let inject_options settings config =
       inject_option ["settings"; "clean_urls"] (boolean settings.clean_urls) |>
       inject_option ["settings"; "page_file_extensions"] (array @@ List.map string settings.page_extensions) |>
       inject_option ["settings"; "markdown_extensions"] (array @@ List.map string settings.markdown_extensions) |>
+      inject_option ["settings"; "markdown_math_delimiters_html"] (boolean settings.markdown_math_delimiters_html) |>
       inject_option ["settings"; "ignore_extensions"] (array []) |>
       inject_option ["settings"; "ignore_path_regexes"] (array []) |>
       inject_option ["settings"; "ignore_directories"] (array []) |>

--- a/src/project_init.ml
+++ b/src/project_init.ml
@@ -81,6 +81,11 @@ let make_default_config settings = Printf.sprintf {|
   # Replace "..." with &hellip;
   markdown_smart_ellipsis = true
 
+  # When using built-in support for CommonMark, by default Soupault will render math
+  # delimiters as `\[ \]` and `\( \)`. Instead you can let Soupault render them as
+  # html (span.math-inline, span.math-display or div.math-display)
+  markdown_math_delimiters_html = false
+
   # By default, soupault uses "clean URLs",
   # that is, $site_dir/page.html is converted to $build_dir/page/index.html
   # You can make it produce $build_dir/page.html instead by changing this option to false


### PR DESCRIPTION
This PR implements optional html math delimiters as described in https://github.com/PataphysicalSociety/soupault/issues/92. 

I moved the code in `make_markdown_renderer` around a little; instead of having one custom renderer, that composes with the default renderer, I created three renderers, each for their own concern and chain-composed them with the default renderer.

`math_span` and `math_block` were largely "borrowed" from the Cmarkit code.

I hope my code is somewhat idiomatic OCaml, please let me know what you think! :-) 