### PR TITLE
Fix cache directory creation for nested paths

### DIFF
--- a/src/cache.ml
+++ b/src/cache.ml
@@ -57,6 +57,8 @@ let cache_object settings page_path identifier source_str output_str =
      [<cache dir>/<path path>/<identifier hash>_<data hash>],
    *)
   let target_path = make_cached_object_path settings page_path identifier source_str in
+  let target_dir = FilePath.dirname target_path in
+  let () = FileUtil.mkdir ~parent:true target_dir in
   let () = Logs.debug @@ fun m -> m "Saving a cached object to %s" target_path in
   write_file target_path output_str
 


### PR DESCRIPTION
## Summary

- Adds `mkdir ~parent:true` before `write_file` in `cache_object` to ensure the directory exists for nested page paths
- Matches the existing pattern used in `refresh_page_cache` (cache.ml:97,105)
- `mkdir` on an existing directory is a no-op, so the call is idempotent

Fixes #86

## Test plan

- [ ] Build and run soupault on a site with nested page paths (e.g., `section/subsection/page.html`)
- [ ] Verify cache writes succeed for pages at any nesting depth
- [ ] Verify no regression for single-level pages